### PR TITLE
Fix deprecation warning in Node 7

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,8 +52,7 @@ Deb.prototype.pack = function (definition, files, callback) {
           fs.unlink.bind(fs, path.join(tempPath, 'data.tar.gz')),
           fs.unlink.bind(fs, path.join(tempPath, 'debian-binary')),
         ], function (err) {
-          fs.rmdir(tempPath)
-          done()
+          fs.rmdir(tempPath, done)
         })
       })
     }

--- a/index.js
+++ b/index.js
@@ -50,8 +50,9 @@ Deb.prototype.pack = function (definition, files, callback) {
         async.parallel([
           fs.unlink.bind(fs, path.join(tempPath, 'control.tar.gz')),
           fs.unlink.bind(fs, path.join(tempPath, 'data.tar.gz')),
-          fs.unlink.bind(fs, path.join(tempPath, 'debian-binary')),
+          fs.unlink.bind(fs, path.join(tempPath, 'debian-binary'))
         ], function (err) {
+          if (err) return done(err)
           fs.rmdir(tempPath, done)
         })
       })


### PR DESCRIPTION
"DeprecationWarning: Calling an asynchronous function without callback is deprecated"