### PR TITLE
Fix test

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var tar = require('tar-stream')
 var fs = require('fs')
+var mkdirp = require('mkdirp')
 var path = require('path')
 var async = require('async')
 var ar = require('ar-async')
@@ -25,7 +26,7 @@ Deb.prototype.pack = function (definition, files, callback) {
   var tempPath = path.resolve(path.join(definition.info.targetDir || '.', 'nbd' + Math.floor(Math.random() * 100000)))
 
   async.series([
-    fs.mkdir.bind(fs, tempPath),
+    mkdirp.bind(mkdirp, tempPath),
     packFiles.bind(this, tempPath, expandFiles(files)),
     buildControlFile.bind(this, tempPath, definition),
     function buildDebBinFile (done) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "async": "^2.0.0-rc.2",
     "debug": "^2.2.0",
     "glob-expand": "^0.1.0",
+    "mkdirp": "^0.5.1",
     "tar-stream": "^1.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
To fix #6 `mkdirp` dependency has been required in order to create recursive directory paths.

It is true that from node 10 onward, native `fs.mkdir` has already included the `recursive` option, but with the intention to maintain node 8 compatibility I understand that adding `mkdirp` is a better solution 😉