### PR TITLE
Fix npm audit

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var tar = require('tar-stream')
 var fs = require('fs')
+var mkdirp = require('mkdirp')
 var path = require('path')
 var async = require('async')
 var ar = require('ar-async')
@@ -25,7 +26,7 @@ Deb.prototype.pack = function (definition, files, callback) {
   var tempPath = path.resolve(path.join(definition.info.targetDir || '.', 'nbd' + Math.floor(Math.random() * 100000)))
 
   async.series([
-    fs.mkdir.bind(fs, tempPath),
+    mkdirp.bind(mkdirp, tempPath),
     packFiles.bind(this, tempPath, expandFiles(files)),
     buildControlFile.bind(this, tempPath, definition),
     function buildDebBinFile (done) {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var async = require('async')
 var ar = require('ar-async')
 var crypto = require('crypto')
 var zlib = require('zlib')
+var glob = require('glob')
 var debug = require('debug')('nobin-debian-installer')
 
 /**
@@ -245,17 +246,20 @@ function addParentDirs (tarball, dir, createdDirs, callback) {
 }
 
 function expandFiles (files) {
-  var expand = require('glob-expand')
   var expandedFiles = []
+
   files.map(function (file) {
-    var sources = expand(file, file.src)
-    sources.map(function (source) {
-      expandedFiles.push({
-        src: [path.join((file.cwd ? file.cwd : ''), source)],
-        dest: path.join(file.dest, source)
+    file.src.forEach(function (pattern) {
+      var sources = glob.sync(pattern, { cwd: file.cwd })
+      sources.forEach(function (source) {
+        expandedFiles.push({
+          src: [path.join((file.cwd ? file.cwd : ''), source)],
+          dest: path.join(file.dest, source)
+        })
       })
     })
   })
+
   return expandedFiles
 }
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ Deb.prototype.pack = function (definition, files, callback) {
       var pkgPath = path.resolve(path.join(definition.info.targetDir || '', pkgName))
 
       debug('creating %s package', pkgPath)
-      var writer = new ar.ArWriter(pkgPath, {variant: 'gnu'})
+      var writer = new ar.ArWriter(pkgPath, { variant: 'gnu' })
       writer.writeEntries([
         path.join(tempPath, 'debian-binary'),
         path.join(tempPath, 'control.tar.gz'),
@@ -112,14 +112,14 @@ function buildControlFile (tempPath, definition, callback) {
           return prlDone(err)
         }
 
-        self.control.entry({name: './control'}, controlHeader, prlDone)
+        self.control.entry({ name: './control' }, controlHeader, prlDone)
       })
     }, function createHashFile (prlDone) {
       var fileContent = ''
       for (var i = 0; i < self.filesMd5.length; i++) {
         fileContent += self.filesMd5[i].md5 + '  ' + self.filesMd5[i].path.replace(/^\W*/, '') + '\n'
       }
-      self.control.entry({name: './md5sums'}, fileContent, prlDone)
+      self.control.entry({ name: './md5sums' }, fileContent, prlDone)
     }, function addScripts (prlDone) {
       async.forEachOf(definition.info.scripts, function (path, scriptName, doneScript) {
         debug('processing script ', path)
@@ -237,7 +237,7 @@ function addParentDirs (tarball, dir, createdDirs, callback) {
     if (!createdDirs[dir]) {
       createdDirs[dir] = 1
       var name = dir === '/' ? './.' : '.' + dir + '/'
-      tarball.entry({name: name, type: 'directory'}, callback)
+      tarball.entry({ name: name, type: 'directory' }, callback)
     } else {
       callback()
     }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ar-async": "^0.1.4",
     "async": "^2.0.0-rc.2",
     "debug": "^2.2.0",
-    "glob-expand": "^0.1.0",
+    "glob": "^7.1.4",
     "mkdirp": "^0.5.1",
     "tar-stream": "^1.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "async": "^2.0.0-rc.2",
     "debug": "^2.2.0",
     "glob-expand": "^0.1.0",
+    "mkdirp": "^0.5.1",
     "tar-stream": "^1.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "tar-stream": "^1.3.2"
   },
   "devDependencies": {
-    "standard": "^6.0.8",
+    "standard": "^13.1.0",
     "tape": "^4.5.1"
   }
 }


### PR DESCRIPTION
This PR tries to fix the vulnerabilities reported by `npm audit`

- Upgrade `standard` version
- Replace deprecated `glob-expand` with `glob`